### PR TITLE
fix: ignoring jetpack ability when player is in GameMode

### DIFF
--- a/src/main/kotlin/xyz/xenondevs/nova/jetpacks/ability/JetpackFlyAbility.kt
+++ b/src/main/kotlin/xyz/xenondevs/nova/jetpacks/ability/JetpackFlyAbility.kt
@@ -19,14 +19,15 @@ import xyz.xenondevs.nova.util.broadcast
 import xyz.xenondevs.nova.util.item.novaItem
 import xyz.xenondevs.nova.util.serverTick
 
+private val IGNORED_GAME_MODES = configReloadable {
+    val modesRaw = NovaConfig["jetpacks:config"].getStringList("ignored_game_mode")
+    GameMode.values().filter { gameMode -> modesRaw.any { it.equals(gameMode.name, ignoreCase = true) } }
+}
 class JetpackFlyAbility(player: Player, flySpeed: Provider<Float>, energyPerTick: Provider<Long>) : Ability(player) {
 
     private val flySpeed: Float by flySpeed
     private val energyPerTick: Long by energyPerTick
-    private val ignoredGameModes: List<GameMode> by configReloadable {
-        val modesRaw = NovaConfig["jetpacks:config"].getStringList("ignored_game_modes")
-        GameMode.values().filter { gameMode -> modesRaw.any { it.equals(gameMode.name, ignoreCase = true) } }
-    }
+    private val ignoredGameModes: List<GameMode> by IGNORED_GAME_MODES
 
     private val wasFlying = player.isFlying
     private val wasAllowFlight = player.allowFlight

--- a/src/main/kotlin/xyz/xenondevs/nova/jetpacks/ability/JetpackFlyAbility.kt
+++ b/src/main/kotlin/xyz/xenondevs/nova/jetpacks/ability/JetpackFlyAbility.kt
@@ -65,6 +65,8 @@ class JetpackFlyAbility(
 
         if (isValidGameMode()) {
             player.flySpeed = flySpeed
+        } else {
+            player.flySpeed = previousFlySpeed
         }
         
         val chargeable = novaItem.getBehavior(Chargeable::class)!!

--- a/src/main/kotlin/xyz/xenondevs/nova/jetpacks/ability/JetpackFlyAbility.kt
+++ b/src/main/kotlin/xyz/xenondevs/nova/jetpacks/ability/JetpackFlyAbility.kt
@@ -71,7 +71,7 @@ class JetpackFlyAbility(
         val energyLeft = chargeable.getEnergy(jetpackItem)
         overlay.percentage = energyLeft / chargeable.options.maxEnergy.toDouble()
         
-        if (energyLeft > energyPerTick) {
+        if (energyLeft > energyPerTick || isValidGameMode().not()) {
             if (player.isFlying) {
                 if (isValidGameMode()) {
                     chargeable.addEnergy(jetpackItem, -energyPerTick)

--- a/src/main/kotlin/xyz/xenondevs/nova/jetpacks/ability/JetpackFlyAbility.kt
+++ b/src/main/kotlin/xyz/xenondevs/nova/jetpacks/ability/JetpackFlyAbility.kt
@@ -7,6 +7,8 @@ import org.bukkit.Sound
 import org.bukkit.entity.Player
 import xyz.xenondevs.commons.provider.Provider
 import xyz.xenondevs.nmsutils.particle.ParticleBuilder
+import xyz.xenondevs.nova.data.config.NovaConfig
+import xyz.xenondevs.nova.data.config.configReloadable
 import xyz.xenondevs.nova.item.behavior.Chargeable
 import xyz.xenondevs.nova.jetpacks.ui.JetpackOverlay
 import xyz.xenondevs.nova.player.ability.Ability
@@ -17,16 +19,14 @@ import xyz.xenondevs.nova.util.broadcast
 import xyz.xenondevs.nova.util.item.novaItem
 import xyz.xenondevs.nova.util.serverTick
 
-class JetpackFlyAbility(
-    player: Player,
-    flySpeed: Provider<Float>,
-    energyPerTick: Provider<Long>,
-    ignoredGameModes: Provider<List<GameMode>>,
-) : Ability(player) {
-    
+class JetpackFlyAbility(player: Player, flySpeed: Provider<Float>, energyPerTick: Provider<Long>) : Ability(player) {
+
     private val flySpeed: Float by flySpeed
     private val energyPerTick: Long by energyPerTick
-    private val ignoredGameModes: List<GameMode> by ignoredGameModes
+    private val ignoredGameModes: List<GameMode> by configReloadable {
+        val modesRaw = NovaConfig["jetpacks:config"].getStringList("ignored_game_modes")
+        GameMode.values().filter { gameMode -> modesRaw.any { it.equals(gameMode.name, ignoreCase = true) } }
+    }
 
     private val wasFlying = player.isFlying
     private val wasAllowFlight = player.allowFlight
@@ -41,20 +41,20 @@ class JetpackFlyAbility(
             player.isFlying = false
             player.flySpeed = this.flySpeed
         }
-        
+
         ActionbarOverlayManager.registerOverlay(player, overlay)
     }
-    
+
     override fun handleRemove() {
         if(isValidGameMode()) {
             player.allowFlight = wasAllowFlight
             player.isFlying = wasFlying
             player.flySpeed = previousFlySpeed
         }
-        
+
         ActionbarOverlayManager.unregisterOverlay(player, overlay)
     }
-    
+
     override fun handleTick() {
         val jetpackItem = jetpackItem
         val novaItem = novaItem
@@ -68,12 +68,12 @@ class JetpackFlyAbility(
         } else {
             player.flySpeed = previousFlySpeed
         }
-        
+
         val chargeable = novaItem.getBehavior(Chargeable::class)!!
         val energyLeft = chargeable.getEnergy(jetpackItem)
         overlay.percentage = energyLeft / chargeable.options.maxEnergy.toDouble()
-        
-        if (energyLeft > energyPerTick || isValidGameMode().not()) {
+
+        if (energyLeft > energyPerTick || !isValidGameMode()) {
             if (player.isFlying) {
                 if (isValidGameMode()) {
                     chargeable.addEnergy(jetpackItem, -energyPerTick)
@@ -92,17 +92,17 @@ class JetpackFlyAbility(
             player.allowFlight = false
         }
     }
-    
+
     override fun reload() {
         if(isValidGameMode()) {
             player.flySpeed = flySpeed
         }
     }
-    
+
     private fun playSound(location: Location) {
         location.world!!.playSound(location, Sound.BLOCK_FIRE_EXTINGUISH, 0.2f, 5f)
     }
-    
+
     private fun spawnParticles(location: Location) {
         location.pitch = 0f
         location.y += 0.5
@@ -111,12 +111,12 @@ class JetpackFlyAbility(
         location.yaw -= 70
         spawnParticle(location.clone().add(location.direction.multiply(0.5)))
     }
-    
+
     private fun spawnParticle(location: Location) {
         val packet = ParticleBuilder(ParticleTypes.FLAME, location).offsetY(-0.5f).build()
         MINECRAFT_SERVER.playerList.broadcast(location, 32.0, packet)
     }
 
     private fun isValidGameMode(): Boolean = player.gameMode !in ignoredGameModes
-    
+
 }

--- a/src/main/kotlin/xyz/xenondevs/nova/jetpacks/ability/JetpackFlyAbility.kt
+++ b/src/main/kotlin/xyz/xenondevs/nova/jetpacks/ability/JetpackFlyAbility.kt
@@ -63,11 +63,9 @@ class JetpackFlyAbility(
             return
         }
 
-        if (isValidGameMode().not()) {
-            return
+        if (isValidGameMode()) {
+            player.flySpeed = flySpeed
         }
-
-        player.flySpeed = flySpeed
         
         val chargeable = novaItem.getBehavior(Chargeable::class)!!
         val energyLeft = chargeable.getEnergy(jetpackItem)
@@ -75,7 +73,10 @@ class JetpackFlyAbility(
         
         if (energyLeft > energyPerTick) {
             if (player.isFlying) {
-                chargeable.addEnergy(jetpackItem, -energyPerTick)
+                if (isValidGameMode()) {
+                    chargeable.addEnergy(jetpackItem, -energyPerTick)
+                }
+
                 if (serverTick % 3 == 0) {
                     val location = player.location
                     playSound(location)
@@ -84,7 +85,7 @@ class JetpackFlyAbility(
             } else {
                 player.allowFlight = true
             }
-        } else if (player.isFlying) {
+        } else if (player.isFlying && isValidGameMode()) {
             player.isFlying = false
             player.allowFlight = false
         }

--- a/src/main/kotlin/xyz/xenondevs/nova/jetpacks/registry/Abilities.kt
+++ b/src/main/kotlin/xyz/xenondevs/nova/jetpacks/registry/Abilities.kt
@@ -1,5 +1,6 @@
 package xyz.xenondevs.nova.jetpacks.registry
 
+import org.bukkit.GameMode
 import xyz.xenondevs.nova.addon.registry.AbilityTypeRegistry
 import xyz.xenondevs.nova.data.config.NovaConfig
 import xyz.xenondevs.nova.data.config.configReloadable
@@ -8,6 +9,10 @@ import xyz.xenondevs.nova.jetpacks.Jetpacks
 import xyz.xenondevs.nova.jetpacks.ability.JetpackFlyAbility
 import xyz.xenondevs.nova.util.data.getFloat
 
+private val IGNORED_GAME_MODES = configReloadable {
+    val modesRaw = NovaConfig["jetpacks:config"].getStringList("ignored_game_mode")
+    GameMode.values().filter { gameMode -> modesRaw.any { it.equals(gameMode.name, ignoreCase = true) } }
+}
 private val BASIC_FLY_SPEED = configReloadable { NovaConfig["jetpacks:basic_jetpack"].getFloat("fly_speed") }
 private val BASIC_ENERGY_PER_TICK = configReloadable { NovaConfig["jetpacks:basic_jetpack"].getLong("energy_per_tick") }
 private val ADVANCED_FLY_SPEED = configReloadable { NovaConfig["jetpacks:advanced_jetpack"].getFloat("fly_speed") }
@@ -20,9 +25,9 @@ private val ULTIMATE_ENERGY_PER_TICK = configReloadable { NovaConfig["jetpacks:u
 @Init
 object Abilities : AbilityTypeRegistry by Jetpacks.registry {
     
-    val BASIC_JETPACK_FLY = registerAbilityType("basic_jetpack_fly") { JetpackFlyAbility(it, BASIC_FLY_SPEED, BASIC_ENERGY_PER_TICK) }
-    val ADVANCED_JETPACK_FLY = registerAbilityType("advanced_jetpack_fly") { JetpackFlyAbility(it, ADVANCED_FLY_SPEED, ADVANCED_ENERGY_PER_TICK) }
-    val ELITE_JETPACK_FLY = registerAbilityType("elite_jetpack_fly") { JetpackFlyAbility(it, ELITE_FLY_SPEED, ELITE_ENERGY_PER_TICK) }
-    val ULTIMATE_JETPACK_FLY = registerAbilityType("ultimate_jetpack_fly") { JetpackFlyAbility(it, ULTIMATE_FLY_SPEED, ULTIMATE_ENERGY_PER_TICK) }
+    val BASIC_JETPACK_FLY = registerAbilityType("basic_jetpack_fly") { JetpackFlyAbility(it, BASIC_FLY_SPEED, BASIC_ENERGY_PER_TICK, IGNORED_GAME_MODES) }
+    val ADVANCED_JETPACK_FLY = registerAbilityType("advanced_jetpack_fly") { JetpackFlyAbility(it, ADVANCED_FLY_SPEED, ADVANCED_ENERGY_PER_TICK, IGNORED_GAME_MODES) }
+    val ELITE_JETPACK_FLY = registerAbilityType("elite_jetpack_fly") { JetpackFlyAbility(it, ELITE_FLY_SPEED, ELITE_ENERGY_PER_TICK, IGNORED_GAME_MODES) }
+    val ULTIMATE_JETPACK_FLY = registerAbilityType("ultimate_jetpack_fly") { JetpackFlyAbility(it, ULTIMATE_FLY_SPEED, ULTIMATE_ENERGY_PER_TICK, IGNORED_GAME_MODES) }
     
 }

--- a/src/main/kotlin/xyz/xenondevs/nova/jetpacks/registry/Abilities.kt
+++ b/src/main/kotlin/xyz/xenondevs/nova/jetpacks/registry/Abilities.kt
@@ -1,6 +1,5 @@
 package xyz.xenondevs.nova.jetpacks.registry
 
-import org.bukkit.GameMode
 import xyz.xenondevs.nova.addon.registry.AbilityTypeRegistry
 import xyz.xenondevs.nova.data.config.NovaConfig
 import xyz.xenondevs.nova.data.config.configReloadable
@@ -9,10 +8,6 @@ import xyz.xenondevs.nova.jetpacks.Jetpacks
 import xyz.xenondevs.nova.jetpacks.ability.JetpackFlyAbility
 import xyz.xenondevs.nova.util.data.getFloat
 
-private val IGNORED_GAME_MODES = configReloadable {
-    val modesRaw = NovaConfig["jetpacks:config"].getStringList("ignored_game_mode")
-    GameMode.values().filter { gameMode -> modesRaw.any { it.equals(gameMode.name, ignoreCase = true) } }
-}
 private val BASIC_FLY_SPEED = configReloadable { NovaConfig["jetpacks:basic_jetpack"].getFloat("fly_speed") }
 private val BASIC_ENERGY_PER_TICK = configReloadable { NovaConfig["jetpacks:basic_jetpack"].getLong("energy_per_tick") }
 private val ADVANCED_FLY_SPEED = configReloadable { NovaConfig["jetpacks:advanced_jetpack"].getFloat("fly_speed") }
@@ -25,9 +20,9 @@ private val ULTIMATE_ENERGY_PER_TICK = configReloadable { NovaConfig["jetpacks:u
 @Init
 object Abilities : AbilityTypeRegistry by Jetpacks.registry {
     
-    val BASIC_JETPACK_FLY = registerAbilityType("basic_jetpack_fly") { JetpackFlyAbility(it, BASIC_FLY_SPEED, BASIC_ENERGY_PER_TICK, IGNORED_GAME_MODES) }
-    val ADVANCED_JETPACK_FLY = registerAbilityType("advanced_jetpack_fly") { JetpackFlyAbility(it, ADVANCED_FLY_SPEED, ADVANCED_ENERGY_PER_TICK, IGNORED_GAME_MODES) }
-    val ELITE_JETPACK_FLY = registerAbilityType("elite_jetpack_fly") { JetpackFlyAbility(it, ELITE_FLY_SPEED, ELITE_ENERGY_PER_TICK, IGNORED_GAME_MODES) }
-    val ULTIMATE_JETPACK_FLY = registerAbilityType("ultimate_jetpack_fly") { JetpackFlyAbility(it, ULTIMATE_FLY_SPEED, ULTIMATE_ENERGY_PER_TICK, IGNORED_GAME_MODES) }
+    val BASIC_JETPACK_FLY = registerAbilityType("basic_jetpack_fly") { JetpackFlyAbility(it, BASIC_FLY_SPEED, BASIC_ENERGY_PER_TICK) }
+    val ADVANCED_JETPACK_FLY = registerAbilityType("advanced_jetpack_fly") { JetpackFlyAbility(it, ADVANCED_FLY_SPEED, ADVANCED_ENERGY_PER_TICK) }
+    val ELITE_JETPACK_FLY = registerAbilityType("elite_jetpack_fly") { JetpackFlyAbility(it, ELITE_FLY_SPEED, ELITE_ENERGY_PER_TICK) }
+    val ULTIMATE_JETPACK_FLY = registerAbilityType("ultimate_jetpack_fly") { JetpackFlyAbility(it, ULTIMATE_FLY_SPEED, ULTIMATE_ENERGY_PER_TICK) }
     
 }

--- a/src/main/resources/configs/config.yml
+++ b/src/main/resources/configs/config.yml
@@ -1,0 +1,3 @@
+ignored_game_mode:
+  - CREATIVE
+  - SPECTATOR

--- a/src/main/resources/configs/config.yml
+++ b/src/main/resources/configs/config.yml
@@ -1,3 +1,3 @@
-ignored_game_mode:
+ignored_game_modes:
   - CREATIVE
   - SPECTATOR


### PR DESCRIPTION
Hi folks! Small contribution for ignoring Removable of Fly when the player is with Jetpack and in GameMode Creative or Spectator.

This also disable losing chargeable or even requiring to have any energy to show particles and sound. 

There is a bunch of if statements, I know, but this was to keep the "Jetpack behavior and effects" while in Creative.